### PR TITLE
fix: fixed tag and moved non-active members to "former"

### DIFF
--- a/content/about/about.md
+++ b/content/about/about.md
@@ -42,11 +42,7 @@ Wonder where our name originates from? _Madrac_ in [Friulan](https://en.wikipedi
     {{< /member >}}
 
     {{< member image="" name="Federico Bertossi" nick="mrBymax" affiliation="University of Udine" github="mrBymax" linkedin="federico-bertossi" mail="hello@federicobertossi.com" twitter="mrBymax" >}}
-        {{< tags "osint" >}}
-    {{< /member >}}
-
-    {{< member image="" name="Gabriele Voltan" nick="GabryV00" affiliation="University of Udine" github="GabryV00" linkedin="gabriele-voltan-065380241" mail="voltan.gabriele@icloud.com" >}}
-        {{< tags "network" "osint" >}}
+        {{< tags "osint" "web" >}}
     {{< /member >}}
     
     {{< member image="" name="Gianluca Zavan" nick="gianzav" affiliation="University of Udine" github="gianzav" linkedin="gianluca-zavan-0a3031293" mail="gianlucagianluca18@gmail.com" >}}
@@ -69,6 +65,10 @@ Wonder where our name originates from? _Madrac_ in [Friulan](https://en.wikipedi
 
     {{< member image="" name="Davide Della Giustina" nick="dsquareg" affiliation="University of Udine" github="davidedellagiustina" linkedin="ddellagiustina" mail="davide@dellagiustina.com" matrix="@dsquareg:matrix.org" >}}
         {{< tags "network" "forensics" >}}
+    {{< /member >}}
+
+    {{< member image="" name="Gabriele Voltan" nick="GabryV00" affiliation="University of Udine" github="GabryV00" linkedin="gabriele-voltan-065380241" mail="voltan.gabriele@icloud.com" >}}
+        {{< tags "network" "osint" >}}
     {{< /member >}}
 
 {{< /members >}}


### PR DESCRIPTION
Fixed tag. Moved players to the right spot.
Maybe we need another commit for the new members.

ps.

<img width="1045" alt="Screenshot 2025-02-14 at 15 01 39" src="https://github.com/user-attachments/assets/3829b9ae-f4e7-469a-9114-95486b9ff4e6" />

@CampaLuca does this qualify me for the "crypto" tag? 😄