### PR TITLE
add privacy policy page

### DIFF
--- a/content/privacy.md
+++ b/content/privacy.md
@@ -10,6 +10,7 @@ layout: single
 Ai sensi del Regolamento (UE) 2016/679 (di seguito "Regolamento"), questa pagina descrive le modalità di trattamento dei dati personali degli utenti che consultano i siti web dell'Associazione MadrHacks (di seguito "MadrHacks") accessibili per via telematica ai seguenti indirizzi:
 
 - https://madrhacks.org
+- https://*.madrhacks.org
 
 Le presenti informazioni non riguardano altri siti, pagine o servizi online raggiungibili tramite link ipertestuali eventualmente pubblicati nei siti ma riferiti a risorse esterne ai domini MadrHacks.
 
@@ -65,4 +66,4 @@ Ogni browser Internet permette di utilizzare, gestire o cancellare i cookie rela
 
 ## Diritti degli interessati
 
-Gli interessati hanno il diritto di ottenere da MadrHacks, nei casi previsti, l'accesso ai propri dati personali e la rettifica o la cancellazione degli stessi o la limitazione del trattamento che li riguarda o di opporsi al trattamento (artt. 15 e ss. del Regolamento). L'apposita istanza è presentata contattando MadrHacks agli indirizzi sopra forniti.
+Gli interessati hanno il diritto di ottenere da MadrHacks, nei casi previsti, l'accesso ai propri dati personali e la rettifica o la cancellazione degli stessi o la limitazione del trattamento che li riguarda o di opporsi al trattamento (artt. 15 e ss. del GDPR). L'apposita istanza è presentata contattando MadrHacks agli indirizzi sopra forniti.

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -1,0 +1,68 @@
+---
+title: 'Informativa Privacy'
+draft: false
+hideToc: false
+layout: single
+---
+
+## Informativa generale sul trattamento dei dati personali nel sito web MadrHacks
+
+Ai sensi del Regolamento (UE) 2016/679 (di seguito "Regolamento"), questa pagina descrive le modalità di trattamento dei dati personali degli utenti che consultano i siti web dell'Associazione MadrHacks (di seguito "MadrHacks") accessibili per via telematica ai seguenti indirizzi:
+
+- https://madrhacks.org
+
+Le presenti informazioni non riguardano altri siti, pagine o servizi online raggiungibili tramite link ipertestuali eventualmente pubblicati nei siti ma riferiti a risorse esterne ai domini MadrHacks.
+
+## Titolare del trattamento
+
+A seguito della consultazione dei siti sopra elencati possono essere trattati dati relativi a persone fisiche identificate o identificabili.
+
+Titolare del trattamento è l'Associazione MadrHacks, con sede in Via Sondrio 2 c/o SMACT3 (Email: [privacy@madrhacks.com](mailto:privacy@madrhacks.com), PEC madrhacks@pec.poste.it)
+
+## Tipi di dati trattati e finalità del trattamento
+
+### Dati di navigazione
+
+I sistemi informatici e le procedure software preposte al funzionamento di questo sito acquisiscono, nel corso del loro normale esercizio, alcuni dati personali la cui trasmissione è implicita nell'uso dei protocolli di comunicazione di Internet.
+
+In questa categoria di dati rientrano gli indirizzi IP o i nomi a dominio dei computer e dei terminali utilizzati dagli utenti, gli indirizzi in notazione URI/URL (Uniform Resource Identifier/Locator) delle risorse richieste, l'orario della richiesta, il metodo utilizzato nel sottoporre la richiesta al server, la dimensione del file ottenuto in risposta, il codice numerico indicante lo stato della risposta data dal server (buon fine, errore, ecc.) ed altri parametri relativi al sistema operativo e all'ambiente informatico dell'utente.
+
+Tali dati, necessari per la fruizione dei servizi web, vengono anche trattati allo scopo di:
+
+- ottenere informazioni statistiche sull'uso dei servizi (pagine più visitate, numero di visitatori per fascia oraria o giornaliera, aree geografiche di provenienza, ecc.);
+- controllare il corretto funzionamento dei servizi offerti.
+
+I dati di navigazione non persistono per più di 365 giorni.
+
+### Dati forniti volontariamente dall'utente
+
+L'invio facoltativo, esplicito e volontario di messaggi agli indirizzi di contatto MadrHacks, i messaggi privati inviati dagli utenti ai profili/pagine MadrHacks sui social media, nonché la compilazione e l'inoltro dei moduli presenti sui siti MadrHacks, comportano l'acquisizione dei dati di contatto del mittente, necessari a rispondere, nonché di tutti i dati personali inclusi nelle comunicazioni. Nel caso di domanda di iscrizione all'associazione i dati forniti saranno trattati con il fine di valutare l'iscrizione all'Associazione. In caso di perfezionamento dell'iscrizione, i dati saranno trattati per la gestione del rapporto associativo, per l'adempimento degli obblighi statutari, amministrativi, contabili e fiscali, nonché per l'invio di comunicazioni relative alle attività, iniziative ed eventi promossi dall'Associazione. I dati potranno inoltre essere comunicati a compagnie assicurative, broker assicurativi o altri soggetti coinvolti nella gestione delle coperture assicurative, esclusivamente per finalità connesse all'attivazione, gestione e tutela assicurativa relativa alle attività dell'Associazione, agli eventi organizzati o alla partecipazione degli associati e/o degli utenti alle iniziative promosse da MadrHacks.
+
+### Cookie e altri sistemi di tracciamento
+
+Il nostro sito web utilizza i cookie per archiviare delle statistiche che ci permettono di migliorare la tua esperienza di navigazione e consentire il funzionamento di video e social networking. I cookie sono file di testo che i siti visitati dagli utenti inviano ai loro terminali e che vengono ritrasmessi ai siti stessi alla visita successiva.
+
+Il nostro sito web utilizza dei cookie necessari al suo funzionamento, spesso denominati cookie tecnici, per:
+
+- consentirti un'agevole navigazione nel sito, memorizzando talune tue scelte per non costringerti a ripeterle ad ogni clic;
+- consentirti l'accesso alle aree riservate del sito.
+
+Questi cookie non raccolgono e non memorizzano alcun dato personale.
+
+In alcune pagine possono essere utilizzate in vari periodi dell'anno dei cookie di terzi legati alle piattaforme di social network che ci consentono di migliorare e monitorare le nostre campagne.
+
+- utilizziamo Facebook per monitorare e migliorare l'andamento di alcune campagne
+
+In questi ultimi casi il nostro sito potrebbe spedire alla piattaforma social alcuni dati sulla tua navigazione e, se in quel momento risulti "loggato" sul social di riferimento, o se inserisci il tuo indirizzo email sulle nostre pagine, questa informazione potrebbe essere associata alla tua identità.
+
+Per comodità riportiamo la gestione dei cookie per ciascuna delle terze parti elencate:
+Facebook/Meta: [informativa privacy](https://www.facebook.com/privacy/explanation) e [utilizzo dei cookie](https://www.facebook.com/policies/cookies/)
+
+### Gestire e cancellare i cookie
+
+Se non desideri comunque accettare i cookie dal nostro sito, puoi disabilitare o cancellare i cookie dalle impostazioni di sicurezza del tuo browser Internet.
+Ogni browser Internet permette di utilizzare, gestire o cancellare i cookie relativi ad ogni sito web navigato.
+
+## Diritti degli interessati
+
+Gli interessati hanno il diritto di ottenere da MadrHacks, nei casi previsti, l'accesso ai propri dati personali e la rettifica o la cancellazione degli stessi o la limitazione del trattamento che li riguarda o di opporsi al trattamento (artt. 15 e ss. del Regolamento). L'apposita istanza è presentata contattando MadrHacks agli indirizzi sopra forniti.

--- a/layouts/partials/sidebar/copyright.html
+++ b/layouts/partials/sidebar/copyright.html
@@ -1,0 +1,7 @@
+<p class="footnote">
+powered by <a target="_blank" href="https://gohugo.io">Hugo</a> | themed with <a target="_blank" href="https://github.com/lukeorth/poison">poison</a>
+    <br>
+    &copy; {{ now.Format "2006"}} {{ or .Site.Language.Params.Author.name .Site.Title }}. All rights reserved.
+    <br>
+    <a href="/privacy/">Informativa Privacy</a>
+</p>


### PR DESCRIPTION
Adds Informativa Privacy (GDPR notice) as a standalone page at /privacy/ and links it from the sidebar footer copyright section.